### PR TITLE
Update dependency version in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,7 @@
   "build-depends": [
   ],
   "depends": [
-    "IO::Socket::Async::SSL:ver<0.7.10>"
+    "IO::Socket::Async::SSL:ver<0.7.14>"
   ],
   "description": "Extendable Internet Relay Chat client",
   "license": "Artistic-2.0",


### PR DESCRIPTION
Bump `IO::Socket::Async::SSL` dependency to `:ver<0.7.14>`, which is both current, and in particular has support for `libssl.so.3` (the version shipped in Ubuntu 22.04 and Linux Mint 21), which `0.7.10` does not.